### PR TITLE
Solve path for windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on: [push,pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, windows]
     strategy:
       max-parallel: 4
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: run-tests
 
-on: [push]
+on: [push,pull_request]
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on: [push,pull_request]
 jobs:
   build:
 
-    runs-on: [ubuntu-latest, windows]
+    runs-on: [ubuntu-latest, windows-latest]
     strategy:
       max-parallel: 4
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,11 +5,12 @@ on: [push,pull_request]
 jobs:
   build:
 
-    runs-on: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 4
       matrix:
         python-version: [3.6, 3.7, 3.8]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v1

--- a/avro_to_python/utils/paths.py
+++ b/avro_to_python/utils/paths.py
@@ -3,6 +3,22 @@
 import os
 from typing import List
 
+def get_joined_path(*paths: str) -> str:
+    """ Gets system paths joined for the current OS
+
+    Parameters
+    ----------
+        paths: str
+            paths to be joined
+
+    Returns
+    -------
+        paths: str
+            joined paths for the current OS
+
+    """
+
+    return os.path.join(*paths)
 
 def get_avsc_files(directory: str) -> List[str]:
     """ Gets system paths for all avsc files in a dir

--- a/avro_to_python/utils/paths.py
+++ b/avro_to_python/utils/paths.py
@@ -3,6 +3,7 @@
 import os
 from typing import List
 
+
 def get_joined_path(*paths: str) -> str:
     """ Gets system paths joined for the current OS
 
@@ -19,6 +20,7 @@ def get_joined_path(*paths: str) -> str:
     """
 
     return os.path.join(*paths)
+
 
 def get_avsc_files(directory: str) -> List[str]:
     """ Gets system paths for all avsc files in a dir
@@ -114,7 +116,7 @@ def verify_or_create_namespace_path(rootdir: str, namespace: str) -> None:
     if not verify_path_exists(rootdir):
         raise OSError('root path does not exist.')
 
-    namespace_path = rootdir + namespace.replace('.', '/') + '/'
+    namespace_path = get_joined_path(rootdir, *namespace.split('.'))
     os.makedirs(namespace_path, exist_ok=True)
 
 

--- a/avro_to_python/writer/writer.py
+++ b/avro_to_python/writer/writer.py
@@ -8,11 +8,11 @@ from avro_to_python.classes.node import Node
 from avro_to_python.utils.avro.helpers import get_union_types
 from avro_to_python.utils.avro.primitive_types import PRIMITIVE_TYPE_MAP
 from avro_to_python.utils.paths import (
-    get_system_path, verify_or_create_namespace_path, get_or_create_path
-)
+    get_system_path, verify_or_create_namespace_path, get_or_create_path,
+    get_joined_path)
 
 
-TEMPLATE_PATH = __file__.replace('writer/writer.py', 'templates/')
+TEMPLATE_PATH = __file__.replace(get_joined_path('writer', 'writer.py'), 'templates/')
 TEMPLATE_PATH = get_system_path(TEMPLATE_PATH)
 
 

--- a/tests/avsc/records/__init__.py
+++ b/tests/avsc/records/__init__.py
@@ -1,0 +1,1 @@
+""" init file for file imports at namespace level """

--- a/tests/avsc/records/helpers.py
+++ b/tests/avsc/records/helpers.py
@@ -1,0 +1,45 @@
+""" helper files for avro serialization """
+
+from enum import Enum, EnumMeta
+
+
+def default_json_serialize(obj):
+    """ Wrapper for serializing enum types """
+    if isinstance(obj, Enum):
+        return obj.name
+    else:
+        return obj.__dict__
+
+
+def todict(obj, classkey=None):
+    """ helper function to convert nested objects to dicts """
+    if isinstance(obj, dict):
+        data = {}
+        for (k, v) in obj.items():
+            data[k] = todict(v, classkey)
+        return data
+    elif isinstance(obj, Enum):
+        return obj.value
+    elif hasattr(obj, "_ast"):
+        return todict(obj._ast())
+    elif hasattr(obj, "__iter__") and not isinstance(obj, str):
+        return [todict(v, classkey) for v in obj]
+    elif hasattr(obj, "__dict__"):
+        data = dict([(key, todict(value, classkey))
+                     for key, value in obj.__dict__.items()
+                     if not callable(value) and not key.startswith('_')])
+        if classkey is not None and hasattr(obj, "__class__"):
+            data[classkey] = obj.__class__.__name__
+        return data
+    else:
+        return obj
+
+
+class DefaultEnumMeta(EnumMeta):
+    default = object()
+
+    def __call__(cls, value=default, *args, **kwargs):
+        if value is DefaultEnumMeta.default:
+            # Assume the first enum is default
+            return next(iter(cls))
+        return super().__call__(value, *args, **kwargs)

--- a/tests/reader/avro/test_reader.py
+++ b/tests/reader/avro/test_reader.py
@@ -5,12 +5,13 @@ import unittest
 
 import avro_to_python
 from avro_to_python.reader.read import AvscReader
+from avro_to_python.utils.paths import get_joined_path
 
 
 class AvroReaderTests(unittest.TestCase):
 
     directory = os.path.abspath(avro_to_python.__file__) \
-        .replace('avro_to_python/__init__.py', 'tests/avsc/records')
+        .replace(get_joined_path('avro_to_python','__init__.py'), 'tests/avsc/records')
 
     def setUp(self):
         pass

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,13 +11,14 @@ from click.testing import CliRunner
 
 import avro_to_python
 from avro_to_python import cli
+from avro_to_python.utils.paths import get_joined_path
 
 
 class CliTests(unittest.TestCase):
     def setUp(self):
         """ place empty avsc files in /tmp dir for testing paths """
         self.source = os.path.abspath(avro_to_python.__file__) \
-            .replace('avro_to_python/__init__.py', 'tests/avsc/records')
+            .replace(get_joined_path('avro_to_python','__init__.py'), 'tests/avsc/records')
 
     def tearDown(self):
         shutil.rmtree('records', ignore_errors=True)

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -11,6 +11,7 @@ from avro_to_python.utils.paths import (
 
 
 class PathTests(unittest.TestCase):
+
     root = os.path.abspath("/tmp")
     temp_dir = os.path.abspath(get_joined_path(root, 'avro'))
     nest_dir = get_joined_path(temp_dir, 'nest')
@@ -21,8 +22,8 @@ class PathTests(unittest.TestCase):
 
         # create tmp dir and files for path testing
 
-        os.mkdir(self.temp_dir)
-        os.mkdir(self.nest_dir)
+        os.makedirs(self.temp_dir)
+        os.makedirs(self.nest_dir)
 
         with open(get_joined_path(self.temp_dir, 'test1.avsc'), 'w') as f:
             f.write('this is a test file')

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,14 +1,13 @@
 """ tests for the reader and reader utils """
 
-
 import os
 import shutil
 import unittest
 
 from avro_to_python.utils.paths import (
     get_avsc_files, get_system_path, verify_path_exists, is_avsc_file,
-    get_or_create_path, verify_or_create_namespace_path
-)
+    get_or_create_path, verify_or_create_namespace_path,
+    get_joined_path)
 
 
 class PathTests(unittest.TestCase):
@@ -34,14 +33,17 @@ class PathTests(unittest.TestCase):
 
     def test_get_avsc_files(self):
         """ tests that avsc files are read correctly """
+        directory = '/tmp/avro'
+        root = os.path.dirname(directory)
+        base_path = os.path.abspath(get_joined_path(root, directory))
         expected = [
-            '/tmp/avro/test1.avsc',
-            '/tmp/avro/nest/test2.avsc'
+            get_joined_path(base_path, 'test1.avsc'),
+            get_joined_path(base_path, 'nest', 'test2.avsc')
         ]
 
-        files = get_avsc_files('/tmp/avro')
+        files = get_avsc_files(directory)
 
-        bad_file = '/tmp/avro/nest/bad.txt' not in files
+        bad_file = get_joined_path('tmp', 'avro', 'nest', 'bad.txt') not in files
 
         self.assertEqual(
             expected,
@@ -83,7 +85,7 @@ class PathTests(unittest.TestCase):
 
     def test_get_system_file_path(self):
         """ tests that you can get the system path of a file """
-        expected = '/tmp/avro/nest/test2.avsc'
+        expected = get_joined_path('tmp', 'avro', 'nest', 'test2.avsc')
 
         # change dir to alter local path
         cwd = os.getcwd()
@@ -91,7 +93,7 @@ class PathTests(unittest.TestCase):
 
         tmp_wd = os.getcwd()
 
-        expected = tmp_wd + '/avro/nest/test2.avsc'
+        expected = get_joined_path(tmp_wd,'avro', 'nest', 'test2.avsc')
 
         path1 = get_system_path('avro/nest/test2.avsc')
 

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -11,29 +11,35 @@ from avro_to_python.utils.paths import (
 
 
 class PathTests(unittest.TestCase):
+    root = os.path.abspath("/tmp")
+    temp_dir = os.path.abspath(get_joined_path(root, 'avro'))
+    nest_dir = get_joined_path(temp_dir, 'nest')
+    test_dir = get_joined_path(root, 'test')
+
     def setUp(self):
         """ place empty avsc files in /tmp dir for testing paths """
 
         # create tmp dir and files for path testing
-        os.mkdir('/tmp/avro')
-        os.mkdir('/tmp/avro/nest')
 
-        with open('/tmp/avro/test1.avsc', 'w') as f:
+        os.mkdir(self.temp_dir)
+        os.mkdir(self.nest_dir)
+
+        with open(get_joined_path(self.temp_dir, 'test1.avsc'), 'w') as f:
             f.write('this is a test file')
 
-        with open('/tmp/avro/nest/test2.avsc', 'w') as f:
+        with open(get_joined_path(self.nest_dir, 'test2.avsc'), 'w') as f:
             f.write('this is another test file')
 
-        with open('/tmp/avro/nest/bad.txt', 'w') as f:
+        with open(get_joined_path(self.nest_dir, 'bad.txt'), 'w') as f:
             f.write('this is not an avsc file')
 
     def tearDown(self):
         # remove the files we created
-        shutil.rmtree('/tmp/avro')
+        shutil.rmtree(self.temp_dir)
 
     def test_get_avsc_files(self):
         """ tests that avsc files are read correctly """
-        directory = '/tmp/avro'
+        directory = self.temp_dir
         root = os.path.dirname(directory)
         base_path = os.path.abspath(get_joined_path(root, directory))
         expected = [
@@ -43,7 +49,7 @@ class PathTests(unittest.TestCase):
 
         files = get_avsc_files(directory)
 
-        bad_file = get_joined_path('tmp', 'avro', 'nest', 'bad.txt') not in files
+        bad_file = get_joined_path(self.nest_dir, 'bad.txt') not in files
 
         self.assertEqual(
             expected,
@@ -58,8 +64,8 @@ class PathTests(unittest.TestCase):
 
     def test_verify_path_exists(self):
         """ tests that file exists function works """
-        should_exist = verify_path_exists('/tmp/avro/nest/test2.avsc')
-        should_not_exist = verify_path_exists('/tmp/avro/test2.avsc')
+        should_exist = verify_path_exists(get_joined_path(self.nest_dir, 'test2.avsc'))
+        should_not_exist = verify_path_exists(get_joined_path(self.temp_dir, 'test2.avsc'))
         self.assertTrue(
             should_exist,
             'expected /tmp/avro/nest/test2.avsc to exist'
@@ -71,8 +77,8 @@ class PathTests(unittest.TestCase):
 
     def test_is_avsc_file(self):
         """ test the is_avsc_file function """
-        is_avsc = is_avsc_file('/tmp/avro/nest/test2.avsc')
-        is_not_avsc = is_avsc_file('/tmp/avro/nest/bad.txt')
+        is_avsc = is_avsc_file(get_joined_path(self.nest_dir, 'test2.avsc'))
+        is_not_avsc = is_avsc_file(get_joined_path(self.nest_dir, 'bad.txt'))
 
         self.assertTrue(
             is_avsc,
@@ -85,21 +91,21 @@ class PathTests(unittest.TestCase):
 
     def test_get_system_file_path(self):
         """ tests that you can get the system path of a file """
-        expected = get_joined_path('tmp', 'avro', 'nest', 'test2.avsc')
+        expected = get_joined_path(self.nest_dir, 'test2.avsc')
 
         # change dir to alter local path
         cwd = os.getcwd()
-        os.chdir('/tmp')
+        os.chdir(self.root)
 
         tmp_wd = os.getcwd()
 
-        expected = get_joined_path(tmp_wd,'avro', 'nest', 'test2.avsc')
+        expected = get_joined_path(tmp_wd, 'avro', 'nest', 'test2.avsc')
 
-        path1 = get_system_path('avro/nest/test2.avsc')
+        path1 = get_system_path(get_joined_path(self.nest_dir, 'test2.avsc'))
 
         # change dir to alter local path
         cwd = os.getcwd()
-        os.chdir('/tmp/avro/nest')
+        os.chdir(self.nest_dir)
         print(os.getcwd())
 
         path2 = get_system_path('test2.avsc')
@@ -119,50 +125,50 @@ class PathTests(unittest.TestCase):
             f'paths not equal: {expected} != {path2}'
         )
 
-        def test_verify_or_create_namespace_path(self):
-            """ tests that verify_or_create_namespace_path works """
-            rootdir = '/tmp'
-            namespace = 'test.namespace.path'
+    def test_verify_or_create_namespace_path(self):
+        """ tests that verify_or_create_namespace_path works """
+        rootdir = self.root
+        namespace = 'test.namespace.path'
 
-            verify_or_create_namespace_path(
-                rootdir=rootdir,
-                namespace=namespace
-            )
+        verify_or_create_namespace_path(
+            rootdir=rootdir,
+            namespace=namespace
+        )
 
-            self.assertTrue(
-                verify_path_exists('/tmp/test/namespace/path/'),
-                'should have created the path from a namespace'
-            )
+        self.assertTrue(
+            verify_path_exists(get_joined_path(self.test_dir, 'namespace', 'path')),
+            'should have created the path from a namespace'
+        )
 
-            verify_or_create_namespace_path(
-                rootdir=rootdir,
-                namespace=namespace
-            )
+        verify_or_create_namespace_path(
+            rootdir=rootdir,
+            namespace=namespace
+        )
 
-            self.assertTrue(
-                verify_path_exists('/tmp/test/namespace/path/'),
-                'should have created the path from a namespace'
-            )
-            os.rmdir('/tmp/test/')
+        self.assertTrue(
+            verify_path_exists(get_joined_path(self.test_dir, 'namespace', 'path')),
+            'should have created the path from a namespace'
+        )
+        shutil.rmtree(self.test_dir)
 
-        def test_get_or_create_path(self):
-            """ tests that get_or_create_path works """
-            path = '/tmp/test'
+    def test_get_or_create_path(self):
+        """ tests that get_or_create_path works """
+        path = self.test_dir
 
-            get_or_create_path(path=path)
+        get_or_create_path(path=path)
 
-            self.assertTrue(
-                verify_path_exists('/tmp/test'),
-                'should have created path at /tmp/test'
-            )
-            os.rmdir(path)
+        self.assertTrue(
+            verify_path_exists(self.test_dir),
+            'should have created path at /tmp/test'
+        )
+        os.rmdir(path)
 
-            os.chdir('/tmp')
+        os.chdir(self.root)
 
-            get_or_create_path(path='test')
+        get_or_create_path(path='test')
 
-            self.assertTrue(
-                verify_path_exists('/tmp/test'),
-                'should have created path at /tmp/test from relative path'
-            )
-            os.rmdir(path)
+        self.assertTrue(
+            verify_path_exists(self.test_dir),
+            'should have created path at /tmp/test from relative path'
+        )
+        shutil.rmtree(path)

--- a/tests/writer/test_compiled_files.py
+++ b/tests/writer/test_compiled_files.py
@@ -8,6 +8,7 @@ import unittest
 
 import avro_to_python
 from avro_to_python.reader.read import AvscReader
+from avro_to_python.utils.paths import get_joined_path
 from avro_to_python.writer.writer import AvroWriter
 
 
@@ -16,13 +17,13 @@ class PathTests(unittest.TestCase):
     def setUp(self):
         """ place empty avsc files in /tmp dir for testing paths """
         self.source = os.path.abspath(avro_to_python.__file__) \
-            .replace('avro_to_python/__init__.py', 'tests/avsc/records')
+            .replace(get_joined_path('avro_to_python', '__init__.py'), 'tests/avsc/records')
         reader = AvscReader(directory=self.source)
         reader.read()
         writer = AvroWriter(reader.file_tree)
 
         self.write_path = os.path.abspath(
-            self.source.replace('tests/avsc/records', '')
+            self.source.replace(get_joined_path('tests', 'avsc', 'records'), '')
         )
 
         writer.write(root_dir=self.write_path)
@@ -234,7 +235,6 @@ class PathTests(unittest.TestCase):
             10
         )
 
-
         self.assertEqual(
             record3.serialize(),
             '{"optionalString": null, "intOrThing": 10, "nullOrThingArray": [{"id": 2}]}'
@@ -284,9 +284,9 @@ class PathTests(unittest.TestCase):
                               {'string2': Thing({'id': 10})}],
                  'intMap': [{'lksdfl': 23}],
                  'thingMap2': [{'string1': {'id': 10}},
-                              {'string2': Thing({'id': 10})}],
+                               {'string2': Thing({'id': 10})}],
                  'thingMap3': [{'string1': {'id': 10}},
-                              {'string2': Thing({'id': 10})}]}
+                               {'string2': Thing({'id': 10})}]}
         data2 = {'thingMap': [{'string1': {'id': 10}},
                               {'string2': Thing({'id': 10})}],
                  'intMap': [{'lksdfl': 'NOT A STRING'}]}


### PR DESCRIPTION
Cool library! At the moment it doesn't work in windows because of the path builder. When it tries to replace with the templates path, it doesn't work because it doesn't find the expression to replace. I did it more standard. Now it should work!