### PR TITLE
Add `map` type support inside `union`

### DIFF
--- a/avro_to_python/utils/avro/helpers.py
+++ b/avro_to_python/utils/avro/helpers.py
@@ -95,6 +95,9 @@ def get_union_types(
         elif obj.fieldtype == 'array':
             out_types.append('list')
 
+        elif obj.fieldtype == 'map':
+            out_types.append('dict')
+
         else:
             raise ValueError('unsupported type')
 

--- a/avro_to_python/utils/avro/types/union.py
+++ b/avro_to_python/utils/avro/types/union.py
@@ -87,6 +87,14 @@ def _union_field(field: dict,
                 references=references
             ))
 
+        elif field_type == 'map':
+            kwargs['union_types'].append(_map_field(
+                field={'name': 'uniontype', 'type': typ},
+                parent_namespace=parent_namespace,
+                queue=queue,
+                references=references
+            ))
+
         # references to previously defined complex types
         # handle reference types
         elif field_type == 'reference':

--- a/avro_to_python/utils/avro/types/union.py
+++ b/avro_to_python/utils/avro/types/union.py
@@ -3,7 +3,6 @@
 from typing import Tuple
 
 from avro_to_python.classes.field import Field
-from avro_to_python.utils.avro.types.map import _map_field
 
 from avro_to_python.utils.avro.types.type_factory import _get_field_type
 from avro_to_python.utils.avro.types.primitive import _primitive_type
@@ -11,6 +10,7 @@ from avro_to_python.utils.avro.types.reference import _reference_type
 from avro_to_python.utils.avro.types.enum import _enum_field
 from avro_to_python.utils.avro.types.record import _record_field
 from avro_to_python.utils.avro.types.array import _array_field
+from avro_to_python.utils.avro.types.map import _map_field
 from avro_to_python.utils.avro.helpers import _get_namespace
 
 

--- a/avro_to_python/utils/avro/types/union.py
+++ b/avro_to_python/utils/avro/types/union.py
@@ -3,6 +3,7 @@
 from typing import Tuple
 
 from avro_to_python.classes.field import Field
+from avro_to_python.utils.avro.types.map import _map_field
 
 from avro_to_python.utils.avro.types.type_factory import _get_field_type
 from avro_to_python.utils.avro.types.primitive import _primitive_type

--- a/tests/avsc/records/RecordWithUnion.avsc
+++ b/tests/avsc/records/RecordWithUnion.avsc
@@ -21,6 +21,13 @@
         "type" : "array",
         "items" : "Thing"
      } ]
-  } ]
+  }, {
+     "name" : "nullOrMap",
+     "type" : [ "null", {
+        "type" : "map",
+        "values": "float"
+     } ]
+  }
+  ]
 }
 

--- a/tests/writer/test_compiled_files.py
+++ b/tests/writer/test_compiled_files.py
@@ -203,7 +203,7 @@ class PathTests(unittest.TestCase):
 
         data1 = {'optionalString': 'hello', 'intOrThing': Thing({'id': 2}), 'nullOrThingArray': None}
         data2 = {'optionalString': 'hello', 'intOrThing': {'id': 2}}
-        data3 = {'optionalString': None, 'intOrThing': 10, 'nullOrThingArray': [{'id': 2}]}
+        data3 = {'optionalString': None, 'intOrThing': 10, 'nullOrThingArray': [{'id': 2}], 'nullOrMap': {'value': 0.1}}
         data4 = {'optionalString': 'hello', 'intOrThing': 'not int or thing'}
 
         record1 = RecordWithUnion(data1)
@@ -211,7 +211,7 @@ class PathTests(unittest.TestCase):
         record3 = RecordWithUnion(data3)
 
         self.assertEqual(
-            '{"optionalString": "hello", "intOrThing": {"id": 2}, "nullOrThingArray": null}',
+            '{"optionalString": "hello", "intOrThing": {"id": 2}, "nullOrThingArray": null, "nullOrMap": null}',
             record1.serialize()
         )
 
@@ -237,7 +237,7 @@ class PathTests(unittest.TestCase):
 
         self.assertEqual(
             record3.serialize(),
-            '{"optionalString": null, "intOrThing": 10, "nullOrThingArray": [{"id": 2}]}'
+            '{"optionalString": null, "intOrThing": 10, "nullOrThingArray": [{"id": 2}], "nullOrMap": {"value": 0.1}}'
         )
 
         with self.assertRaises(TypeError):


### PR DESCRIPTION
This PR adds support of `map` type inside union.
Schema excerpt that caused the error at https://github.com/SRserves85/avro-to-python/blob/bacb3e6eb8bb09bb0a4702f6a5f48a3ef89e11f2/avro_to_python/utils/avro/types/union.py#L101:

```json
...,
{
  "name": "some_name",
  "type": [
    "null",
    {
      "type": "map",
      "values": "float"
    }
  ],
  "default": null
},
...
```

@SRserves85 @irux @chasdevs Please let me know if this makes sense so I could add the tests for the case.