### PR TITLE
Feature/fix import and update dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,7 @@ To use the cli, here is the available cli commands:
     avro-to-python [source] [target]
         Options:
             --pip TEXT              make package pip installable using this name
+            --top_level_package     override top level package name (optional)
             --author TEXT           author name of the pip installable package
             --package_version TEXT  version of the pip intallable package  [default: 0.1.0]
             --help                  Show this message and exit
@@ -81,6 +82,17 @@ If you run the above on a valid avro avsc file, you should then be able to impor
 
     record = RecordClass({'foo': True, 'bar': 'true', 'baz': 10, 'food': 'CHOCOLATE'})
 
+Tips: To generate classes in a subpackage of your existing application set the "--top_level_package" flags to *..* value:
+
+.. code-block:: bash
+
+    avro-to-python [path_to_source_avsc_files] [path_to_mysubpackage_directory] --top_level_package ..
+
+.. code-block:: python
+
+    from mysubpackage.name.space import RecordClass
+
+    record = RecordClass({'foo': True, 'bar': 'true', 'baz': 10, 'food': 'CHOCOLATE'})
 
 CLI (with --pip)
 ----------------
@@ -100,6 +112,18 @@ Now that you have the package installed, you can import it by it's package name 
 .. code-block:: python
 
     from test_avro.name.space import RecordClass
+
+    record = RecordClass({'foo': True, 'bar': 'true', 'baz': 10, 'food': 'CHOCOLATE'})
+
+You can customize the top level package name *test_avro*, modifying the "--top_level_package" flags:
+
+.. code-block:: bash
+
+    avro-to-python [path_to_source_avsc_files] [path_to_target_directory] --pip test_avro --top_level_package event
+
+.. code-block:: python
+
+    from event.name.space import RecordClass
 
     record = RecordClass({'foo': True, 'bar': 'true', 'baz': 10, 'food': 'CHOCOLATE'})
 

--- a/README.rst
+++ b/README.rst
@@ -82,15 +82,15 @@ If you run the above on a valid avro avsc file, you should then be able to impor
 
     record = RecordClass({'foo': True, 'bar': 'true', 'baz': 10, 'food': 'CHOCOLATE'})
 
-Tips: To generate classes in a subpackage of your existing application set the "--top_level_package" flags to *..* value:
+Tips: To generate classes in a subpackage of your existing application set the "--top_level_package" flags to your subpackage name:
 
 .. code-block:: bash
 
-    avro-to-python [path_to_source_avsc_files] [path_to_mysubpackage_directory] --top_level_package ..
+    avro-to-python [path_to_source_avsc_files] [path_to_my_subpackage_directory] --top_level_package my.subpackage
 
 .. code-block:: python
 
-    from mysubpackage.name.space import RecordClass
+    from my.subpackage.name.space import RecordClass
 
     record = RecordClass({'foo': True, 'bar': 'true', 'baz': 10, 'food': 'CHOCOLATE'})
 

--- a/avro_to_python/cli.py
+++ b/avro_to_python/cli.py
@@ -20,9 +20,10 @@ VERSION_HELP = 'version of the pip intallable package'
 @click.argument('source', type=Path(), default=None)
 @click.argument('target', type=Path(), default=None)
 @click.option('--pip', type=str, default=None, required=False, show_default=True, help=PIP_HELP)  # NOQA
+@click.option('--top_level_package', type=str, default=None, required=False, show_default=True, help=PIP_HELP)  # NOQA
 @click.option('--author', type=str, default=None, required=False, show_default=True, help=AUTHOR_HELP)  # NOQA
 @click.option('--package_version', type=str, default='0.1.0', required=False, show_default=True, help=VERSION_HELP)  # NOQA
-def main(source, target, pip=None, author=None, package_version=None):
+def main(source, target, pip=None, top_level_package=None, author=None, package_version=None):
     """avro-to-python: compile avro avsc schemata to python classes
     """
 
@@ -34,6 +35,7 @@ def main(source, target, pip=None, author=None, package_version=None):
     writer = AvroWriter(
         reader.file_tree,
         pip=pip,
+        top_level_package=top_level_package,
         author=author,
         package_version=package_version
     )

--- a/avro_to_python/writer/writer.py
+++ b/avro_to_python/writer/writer.py
@@ -105,10 +105,10 @@ class AvroWriter(object):
         root_dir = get_system_path(root_dir)
         if self.pip:
             self.root_dir = os.path.join(root_dir, self.pip)
-            self.top_level_package_dir = os.path.join(self.root_dir, self.top_level_package)
         else:
             self.root_dir = root_dir
-            self.top_level_package_dir = self.root_dir
+
+        self.top_level_package_dir = os.path.join(self.root_dir, self.top_level_package.replace(".", os.sep))
 
         if self.top_level_package:
             self.pip_import = self.top_level_package + "."

--- a/avro_to_python/writer/writer.py
+++ b/avro_to_python/writer/writer.py
@@ -105,10 +105,10 @@ class AvroWriter(object):
         root_dir = get_system_path(root_dir)
         if self.pip:
             self.root_dir = os.path.join(root_dir, self.pip)
+            self.top_level_package_dir = os.path.join(self.root_dir, self.top_level_package)
         else:
             self.root_dir = root_dir
-
-        self.top_level_package_dir = os.path.join(self.root_dir, self.top_level_package)
+            self.top_level_package_dir = self.root_dir
 
         if self.top_level_package:
             self.pip_import = self.top_level_package + "."

--- a/avro_to_python/writer/writer.py
+++ b/avro_to_python/writer/writer.py
@@ -101,7 +101,7 @@ class AvroWriter(object):
             self.root_dir += '/' + self.pip + '/' + self.pip.replace('-', '_')
             self.pip = self.pip.replace('-', '_')
         else:
-            self.pip_import = ''
+            self.pip_import = '..'
         get_or_create_path(self.root_dir)
         self._write_helper_file()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Jinja2>=2.10.3
-Click>=8.0
+Click>=7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Jinja2==2.10.3
-Click==7.0
+Jinja2>=2.10.3
+Click>=8.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,10 +3,10 @@ bump2version==0.5.11
 wheel==0.33.6
 watchdog==0.9.0
 flake8==3.7.8
-tox==3.14.0
+tox>=3.21.0,<=3.24.4
 coverage==4.5.4
 Sphinx==1.8.5
 twine==1.14.0
-Click==7.0
+Click>=7.0,<=8.0
 pytest==4.6.5
 pytest-runner==5.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,7 +3,7 @@ bump2version==0.5.11
 wheel==0.33.6
 watchdog==0.9.0
 flake8==3.7.8
-tox>=3.21.0,<=3.24.4
+tox>=3.14.0,<=3.24.4
 coverage==4.5.4
 Sphinx==1.8.5
 twine==1.14.0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements = ['Jinja2==2.10.3', 'Click==7.0']
+requirements = ['Jinja2>=2.10.3', 'Click>=7.0,<=8.0']
 
 test_requirements = [
     'pip==19.2.3',
@@ -19,14 +19,14 @@ test_requirements = [
     'wheel==0.33.6',
     'watchdog==0.9.0',
     'flake8==3.7.8',
-    'tox==3.14.0',
+    'tox>=3.14.0',
     'coverage==4.5.4',
     'Sphinx==1.8.5',
     'twine==1.14.0',
-    'Click==7.0',
+    'Click>=7.0,<=8.0',
     'pytest==4.6.5',
     'pytest-runner==5.1',
-    'Jinja2==2.10.3'
+    'Jinja2>=2.10.3'
 ]
 
 setup(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,9 +22,10 @@ class CliTests(unittest.TestCase):
 
     def tearDown(self):
         shutil.rmtree('records', ignore_errors=True)
-        shutil.rmtree('test-avro', ignore_errors=True)
+        shutil.rmtree('test-pip', ignore_errors=True)
+        shutil.rmtree('test-top-level-package', ignore_errors=True)
 
-    def test_command_line_interface(self):
+    def test_cli_interface(self):
         """Test the CLI."""
         runner = CliRunner()
         result = runner.invoke(cli.main)
@@ -34,23 +35,23 @@ class CliTests(unittest.TestCase):
         assert help_result.exit_code == 0
         assert 'Show this message and exit.' in help_result.output
 
-    def test_pip_command_line(self):
+    def test_pip_cli(self):
         """ tests that the cli can make a non-pip run """
         runner = CliRunner()
-        args = [self.source, './', '--pip', 'test-avro']
+        args = [self.source, './', '--pip', 'test-pip']
         result = runner.invoke(cli.main, args)
         assert result.exit_code == 0
 
         # Install the package using -e for local
         subprocess.check_call(
-            [sys.executable, '-m', 'pip', 'install', '-e', './test-avro']
+            [sys.executable, '-m', 'pip', 'install', '-e', './test-pip']
         )
 
         # when pip installing, it isn't actually added to $PATH
-        sys.path.append('test-avro')
+        sys.path.append('test-pip')
 
         # import a namespace
-        from test_avro.records import RecordWithRecord
+        from test_pip.records import RecordWithRecord
 
         data1 = {'thing1': {'id': 10}, 'thing2': {'id': 0}}
         record1 = RecordWithRecord(data1)
@@ -61,6 +62,37 @@ class CliTests(unittest.TestCase):
         )
 
         subprocess.check_call(
-            [sys.executable, '-m', 'pip', 'uninstall', '-y', 'test-avro']
+            [sys.executable, '-m', 'pip', 'uninstall', '-y', 'test-pip']
+        )
+        del runner
+
+    def test_top_level_package_cli(self):
+        """ tests that the cli can make a non-pip run """
+        runner = CliRunner()
+        args = [self.source, './', '--pip', 'test-top-level-package', '--top_level_package', 'event']
+        result = runner.invoke(cli.main, args)
+        assert result.exit_code == 0
+
+        # Install the package using -e for local
+        subprocess.check_call(
+            [sys.executable, '-m', 'pip', 'install', '-e', './test-top-level-package']
+        )
+
+        # when pip installing, it isn't actually added to $PATH
+        sys.path.append('test-top-level-package')
+
+        # import a namespace
+        from event.records import RecordWithRecord
+
+        data1 = {'thing1': {'id': 10}, 'thing2': {'id': 0}}
+        record1 = RecordWithRecord(data1)
+
+        self.assertEqual(
+            json.dumps(data1),
+            record1.serialize()
+        )
+
+        subprocess.check_call(
+            [sys.executable, '-m', 'pip', 'uninstall', '-y', 'test-top-level-package']
         )
         del runner


### PR DESCRIPTION
Objective of this PR is to give the capability to generate Python classes in a subpackage of an existing application. (See: [16](https://github.com/SRserves85/avro-to-python/issues/16))

It add a new flag that allow to override the default top level package name chosen for classes generation.
For information, top level package is currently : 

- When pip:
   pip value with `'-' -> '_'` replacement
   Ex : test-avro became test_avro
   
- Without pip:
  blank
  
How-to : 
Using this new flag, it is now possible to generate classes without pip but with a custom top level package.
Example : 
```
with pkg_resources.path(api, "event") as event_directory:
        # initialize the reader object
        reader = AvscReader(directory=event_directory)

        # generate the acyclic tree object
        reader.read()

        # initialize the writer object
        writer = AvroWriter(reader.file_tree, top_level_package="api.event")

        # compile python files using 'tests/test_records as the namespace root'
        writer.write(root_dir="."))
```

Bonus : 
We updated the package dependencies to use ranges of compatibility instead of fixed value.
This is useful in projects where these dependencies are already set to fixed value which is distinct from this library.