### PR TITLE
Correct handling of fullnames.

### DIFF
--- a/avro_to_python/reader/read.py
+++ b/avro_to_python/reader/read.py
@@ -14,7 +14,7 @@ from avro_to_python.utils.exceptions import (
     NoFileOrDir, MissingFileError, NoFilesError
 )
 
-from avro_to_python.utils.avro.helpers import _get_namespace
+from avro_to_python.utils.avro.helpers import _get_name, _get_namespace
 from avro_to_python.utils.avro.files.enum import _enum_file
 from avro_to_python.utils.avro.files.record import _record_file
 
@@ -139,8 +139,9 @@ class AvscReader(object):
             # get first item in queue
             item = queue.pop(0)
 
-            # impute namespace
+            # impute namespace and name
             item['namespace'] = _get_namespace(item)
+            item['name'] = _get_name(item)
 
             # traverse to namespace starting from root_node
             current_node = self._traverse_tree(


### PR DESCRIPTION
As per the Avro spec:

> A fullname is specified. If the name specified contains a dot,
> then it is assumed to be a fullname, and any namespace also specified
> is ignored.

It's not completely clear that this also replaces the namespace for nested types,
but that is how the Java avro-tools jar handles it, which I've used as
the reference implementation.

Obviously, it should be preferred to not set both the name field to a
fullname and also the namespace field, but we have done this in some
legacy schemas and can't change them now, since the Schema Registry
validator doens't allow changing the name.
