### PR TITLE
Sort imports in the __init__.py files.

### DIFF
--- a/avro_to_python/writer/writer.py
+++ b/avro_to_python/writer/writer.py
@@ -159,7 +159,7 @@ class AvroWriter(object):
         """ writes __init__.py files for namespace imports"""
         template = self.template_env.get_template('files/init.j2')
         filetext = template.render(
-            imports=imports,
+            imports=sorted(imports),
             pip_import=self.pip_import
         )
         verify_or_create_namespace_path(


### PR DESCRIPTION
We commit these generated files to version control. Thus the output
should be a static as possible. Sorting the imports avoids them being
rearranged randomly.
