### PR TITLE
Adding option for specifying an alternate template

### DIFF
--- a/avro_to_python/cli.py
+++ b/avro_to_python/cli.py
@@ -14,6 +14,7 @@ from avro_to_python.writer.writer import AvroWriter
 PIP_HELP = 'make package pip installable using this name'
 AUTHOR_HELP = 'author name of the pip installable package'
 VERSION_HELP = 'version of the pip intallable package'
+TEMPLATE_PATH_HELP = 'path to a folder containing templates for the output'
 
 
 @click.command()
@@ -23,7 +24,8 @@ VERSION_HELP = 'version of the pip intallable package'
 @click.option('--top_level_package', type=str, default=None, required=False, show_default=True, help=PIP_HELP)  # NOQA
 @click.option('--author', type=str, default=None, required=False, show_default=True, help=AUTHOR_HELP)  # NOQA
 @click.option('--package_version', type=str, default='0.1.0', required=False, show_default=True, help=VERSION_HELP)  # NOQA
-def main(source, target, pip=None, top_level_package=None, author=None, package_version=None):
+@click.option('--template_path', type=str, default=None, required=False, show_default=True, help=TEMPLATE_PATH_HELP)  # NOQA
+def main(source, target, pip=None, top_level_package=None, author=None, package_version=None, template_path=None):
     """avro-to-python: compile avro avsc schemata to python classes
     """
 
@@ -37,7 +39,8 @@ def main(source, target, pip=None, top_level_package=None, author=None, package_
         pip=pip,
         top_level_package=top_level_package,
         author=author,
-        package_version=package_version
+        package_version=package_version,
+        template_path=template_path
     )
     writer.write(root_dir=target)
     del reader

--- a/avro_to_python/writer/writer.py
+++ b/avro_to_python/writer/writer.py
@@ -54,7 +54,7 @@ class AvroWriter(object):
     files = []
 
     def __init__(self, tree: dict, pip: str=None, top_level_package: str=None, author: str=None,
-                 package_version: str=None) -> None:
+                 package_version: str=None, template_path: str=None) -> None:
         """ Parses tree structured dictionaries into python files
 
         Parameters
@@ -87,7 +87,7 @@ class AvroWriter(object):
         self.tree = tree
 
         # jinja2 templates
-        self.template_env = Environment(loader=FileSystemLoader(TEMPLATE_PATH))
+        self.template_env = Environment(loader=FileSystemLoader(template_path or TEMPLATE_PATH))
         self.template = self.template_env.get_template('baseTemplate.j2')
 
     def write(self, root_dir: str) -> None:


### PR DESCRIPTION
## Problem

The standard template is useful for most use-cases I would assume but in the case of users of [Apache Pulsar](https://pulsar.apache.org) the classes need to be structured differently, inheriting their libraries.

Example Record ([see docs](https://pulsar.apache.org/docs/client-libraries-python#schema-definition-examples))

**avsc**
```json
{
    "name": "UserSignedUp",
    "type": "record",
    "namespace": "user_app.user.signed_up",
    "fields": [
        {
            "name": "displayName",
            "doc": "Name of the user",
            "default": null,
            "type": [
                "null",
                "string"
            ]
        },
        {
            "name": "email",
            "doc": "Email of the user",
            "default": null,
            "type": [
                "null",
                "string"
            ]
        }
    ]
}
```

**generated**
```python
from pulsar.schema import Record, String

class UserSignedUp(Record):
    _avro_namespace = "user_app.user.signed_up"
    # Name of the user
    displayName = String(required=False)
    # Email of the user
    email = String(required=False)
```

## Solution

In this pull request I'm not proposing all different types of templated output but rather just support passing a flag to the CLI (or optional parameter to the Writer) to specify a folder where your template is.